### PR TITLE
getTrack function returns the duration of the track

### DIFF
--- a/src/lib/API.ts
+++ b/src/lib/API.ts
@@ -49,6 +49,7 @@ export default class SpotifyApi {
         details.album_name = data.album.name
         details.release_date = data.album.release_date
         details.cover_url = data.album.images[0].url
+        details.duration_ms = data.duration_ms
         return details
     }
 

--- a/src/lib/details/Track.ts
+++ b/src/lib/details/Track.ts
@@ -6,6 +6,7 @@ export default class TrackDetails implements ITrack {
         public artists: string[] = [],
         public album_name = '',
         public release_date = '',
-        public cover_url = ''
-    ) {}
+        public cover_url = '',
+        public duration_ms = 0
+    ) { }
 }


### PR DESCRIPTION
Noticed that the getTrack function wasn't returning the duration of the track and thought I'd add it. I think it is useful for a lot of use cases.